### PR TITLE
Conform version indentifier in setup.py to PEP 440

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Changelog for Rapid Photo Downloader
 ====================================
 
+0.9.35 (2023-xx-xx)
+-------------------
+
+ - Conform version indentifier in `setup.py` to PEP 440 which is enforced with
+   setuptools >= 66.0.0
+
 0.9.34 (2022-11-02)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ setup(
         "raphodo.metadata.analysis",
         "raphodo.prefs",
     ],
-    python_requires=">=3.6.*, <4",
+    python_requires=">=3.6, <4",
     entry_points={
         "gui_scripts": ["rapid-photo-downloader=raphodo.rapid:main"],
     },


### PR DESCRIPTION
This is enforced with setuptools >= 66.0.0

In the current state, building with version 66.0.0 and higher results in:

`error in rapid-photo-downloader setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.6.*'
`