### PR TITLE
Mitigate invalid cross-device link errors

### DIFF
--- a/raphodo/renameandmovefile.py
+++ b/raphodo/renameandmovefile.py
@@ -897,7 +897,7 @@ class RenameMoveFileWorker(DaemonProcess):
             )
             try:
                 os.rename(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)
-            except Exception as inst:
+            except OSError as inst:
                 if inst.errno == errno.EXDEV:
                     logging.debug("....invalid cross-device link detected, falling back to full copy operation")
                     shutil.move(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)

--- a/raphodo/renameandmovefile.py
+++ b/raphodo/renameandmovefile.py
@@ -895,14 +895,7 @@ class RenameMoveFileWorker(DaemonProcess):
                 rpd_file.temp_full_file_name,
                 rpd_file.download_full_file_name,
             )
-            try:
-                os.rename(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)
-            except OSError as inst:
-                if inst.errno == errno.EXDEV:
-                    logging.debug("....invalid cross-device link detected, falling back to full copy operation")
-                    shutil.move(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)
-                else:
-                    raise inst
+            shutil.move(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)
             logging.debug("....successfully renamed file")
             move_succeeded = True
             if rpd_file.status != DownloadStatus.downloaded_with_warning:

--- a/raphodo/renameandmovefile.py
+++ b/raphodo/renameandmovefile.py
@@ -901,6 +901,8 @@ class RenameMoveFileWorker(DaemonProcess):
                 if inst.errno == errno.EXDEV:
                     logging.debug("....invalid cross-device link detected, falling back to full copy operation")
                     shutil.move(rpd_file.temp_full_file_name, rpd_file.download_full_file_name)
+                else:
+                    raise inst
             logging.debug("....successfully renamed file")
             move_succeeded = True
             if rpd_file.status != DownloadStatus.downloaded_with_warning:


### PR DESCRIPTION
  - When downloading photos, a rename operation is used to move tmp files to their final destination. This operation won't work when soft links are used between devices, resulting in a `Error: 18 Invalid cross-device link` error.
  - Cross device links can be useful in different scenarios. One example is storing RAW files in a different device, using soft links and extension-based subfolder generation.
  - A possible mitigation is to try to use rename (fast) and fall back to a full file copy when such error is found. This provides a good tradeoff between performance and flexibility.
  - Solution based on https://bugs.launchpad.net/rapid/+bug/1815546/comments/5
  - Fixes https://github.com/damonlynch/rapid-photo-downloader/issues/100