### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ __copyright__ = (
 
 import os
 from glob import glob
-from distutils.command.build import build
 from setuptools import setup, Command
 from setuptools.command.sdist import sdist
+from distutils.command.build import build
 
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Hi Damon,

as you might recall, I'm one of the Debian maintainers of your program rapid-photo-downloader. I'd like to forward a patch from Stefano Rivera via PR. This patch is to prepare for Python 3.12, which will drop distutils.

Regards,
Tobias
