### PR TITLE
build: Convert project configuration and build to use Hatch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Changelog for Rapid Photo Downloader
 0.9.37 (2024-03-xx)
 -------------------
 
- - Convert project configuration and build to use pyproject.toml.
+ - Convert project configuration and build to use 
+   [Hatch](https://github.com/pypa/hatch).
 
  - Purge use of the Qt resource system for images, instead storing images in a 
    new data directory and loading them using the Python resource system.


### PR DESCRIPTION
Converted project configuration and build to utilize Hatch as a tool for 
managing project configuration and building. This change streamlines the 
development process and improves the overall project structure. 