### PR TITLE
build: Explain switch to Hatch for build process and localisation file generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 venv/
 __pycache__/
 dist/
+sdist/
 raphodo/locale/
 tasks/copycode.py
 tools/remove_screenshot_border.py

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,9 @@ Changelog for Rapid Photo Downloader
 -------------------
 
  - Convert project configuration and build to use 
-   [Hatch](https://github.com/pypa/hatch).
+   [Hatch](https://github.com/pypa/hatch), 
+   which has resulted in changes to program configuration. Linux distribution
+   packagers should consult the release notes for details.
 
  - Fix bug [#154](https://github.com/damonlynch/rapid-photo-downloader/issues/154):
    System-mounted Windows drives not detected as mounted under WSL.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,18 @@
 Release Notes for Rapid Photo Downloader 0.9.36
 ===============================================
 
+ - Rapid Photo Downloader 0.9.37 switches from `setuptools` and an old-school
+   `setup.py` to using [Hatch](https://github.com/pypa/hatch).
+   As part of this switch, localisation files are generated differently:
+   - `.desktop` and `metainfo.xml` files are now generated at build time into 
+     subfolders within the `share` folder.
+   - `.mo` files are now generated within the folder `raphodo/locale`; they
+      should not be copied to `/usr/share/locale`. Any 
+     `rapid-photo-downloader.mo` files in `/usr/share/locale` should be 
+     deleted. 
+
+ - Rapid Photo Downloader 0.9.35 requires Python 3.10 or newer.
+
  - To run Rapid Photo Downloader under WSLg on Windows 11, using the 
    [Windows Subsystem for Linux Preview](https://aka.ms/wslstorepage) from 
    the Microsoft Store is *strongly recommended*. Using the version of WSL that
@@ -8,16 +20,6 @@ Release Notes for Rapid Photo Downloader 0.9.36
    running programs like Rapid Photo Downloader. Read the documentation on Rapid
    Photo Downloader and WSL on the
    [program website](https://https://damonlynch.net/rapid/documentation/#wsl).
-
- - Rapid Photo Downloader 0.9.35 requires Python 3.10 or newer.
-
- - Rapid Photo Downloader 0.9.19 introduced support for HEIF / HEIC files. The 
-   [documentation](https://damonlynch.net/rapid/documentation/#heifheic) 
-   goes into details.
-
- - Version 0.9.19 also introduced much improved support for high-resolution
-   displays. Consult the [documentation](https://damonlynch.net/rapid/documentation/#highdpi)
-   to learn more.
 
  - If thumbnailing fails to finish but no error is reported, that could indicate
    Exiv2 has crashed. See the 

--- a/raphodo/__init__.py
+++ b/raphodo/__init__.py
@@ -11,7 +11,7 @@ import locale
 import os
 from pathlib import Path
 
-from PyQt5.QtCore import QSettings, QStandardPaths
+from PyQt5.QtCore import QSettings
 
 
 def sample_translation() -> str:
@@ -21,45 +21,6 @@ def sample_translation() -> str:
 
     mo_file = f"{i18n_domain}.mo"
     return os.path.join("es", "LC_MESSAGES", mo_file)
-
-
-def locale_directory() -> str | None:
-    """
-    Locate locale directory. Prioritizes whatever is newer, comparing the locale
-    directory at xdg_data_home and the one in /usr/share/
-
-    If running in a snap, use the snap locale directory.
-
-    :return: the locale directory with the most recent messages for Rapid Photo
-    Downloader, if found, else None.
-    """
-
-    snap_name = os.getenv("SNAP_NAME", "")
-    if snap_name.find("rapid-photo-downloader") >= 0:
-        snap_dir = os.getenv("SNAP", "")
-        return os.path.join(snap_dir, "/usr/lib/locale")
-
-    locale_dir = os.getenv("RPD_I18N_DIR")
-    if locale_dir is not None and os.path.isdir(locale_dir):
-        return locale_dir
-
-    sample_lang_path = sample_translation()
-    locale_mtime = 0.0
-    locale_dir = None
-
-    data_home = QStandardPaths.writableLocation(QStandardPaths.GenericDataLocation)
-    assert Path(data_home).is_dir()
-
-    for path in (data_home, "/usr/share"):
-        locale_path = os.path.join(path, "locale")
-        sample_path = os.path.join(locale_path, sample_lang_path)
-        if (
-            os.path.isfile(sample_path)
-            and os.access(sample_path, os.R_OK)
-            and os.path.getmtime(sample_path) > locale_mtime
-        ):
-            locale_dir = locale_path
-    return locale_dir
 
 
 def no_translation_performed(s: str) -> str:
@@ -76,7 +37,7 @@ def no_translation_performed(s: str) -> str:
 
 
 i18n_domain = "rapid-photo-downloader"
-localedir = locale_directory()
+localedir = Path(__file__).parent / "locale"
 
 lang = None
 lang_installed = False


### PR DESCRIPTION
Get .mo files from local locale directory, not /usr/share/locale