### PR TITLE
refactor: move internationalisation utilities

### DIFF
--- a/raphodo/argumentsparse.py
+++ b/raphodo/argumentsparse.py
@@ -9,8 +9,11 @@ import platform
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 from raphodo import __about__ as __about__
-from raphodo.metadata import fileformats as fileformats
-from raphodo.tools.utilities import make_internationalized_list
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import make_internationalized_list
+from raphodo.metadata.fileextensions import OTHER_PHOTO_EXTENSIONS
+
+install_gettext()
 
 
 def get_parser(formatter_class=RawDescriptionHelpFormatter) -> ArgumentParser:
@@ -162,9 +165,7 @@ def get_parser(formatter_class=RawDescriptionHelpFormatter) -> ArgumentParser:
         action="store_true",
         dest="ignore_other",
         help=_("Ignore photos with the following extensions: %s")
-        % make_internationalized_list(
-            [s.upper() for s in fileformats.OTHER_PHOTO_EXTENSIONS]
-        ),
+        % make_internationalized_list([s.upper() for s in OTHER_PHOTO_EXTENSIONS]),
     )
     parser.add_argument(
         "--auto-download-startup",

--- a/raphodo/copyfiles.py
+++ b/raphodo/copyfiles.py
@@ -23,6 +23,7 @@ import gphoto2 as gp
 
 from raphodo.camera import Camera, CameraProblemEx, gphoto2_python_logging
 from raphodo.constants import CameraErrorCode, DownloadStatus, FileType
+from raphodo.internationalisation.install import install_gettext
 from raphodo.interprocess import (
     CopyFilesArguments,
     CopyFilesResults,
@@ -46,6 +47,8 @@ from raphodo.tools.utilities import (
     create_temp_dirs,
     same_device,
 )
+
+install_gettext()
 
 
 def copy_file_metadata(src: str, dst: str) -> tuple | None:

--- a/raphodo/devices.py
+++ b/raphodo/devices.py
@@ -34,6 +34,8 @@ from raphodo.constants import (
     FileType,
     FileTypeFlag,
 )
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import make_internationalized_list
 from raphodo.problemnotification import FsMetadataWriteProblem
 from raphodo.rpdfile import FileSizeSum, FileTypeCounter, Photo, RPDFile, Video
 from raphodo.storage.storage import (
@@ -53,11 +55,12 @@ from raphodo.storage.storageidevice import (
 )
 from raphodo.tools.utilities import (
     data_file_path,
-    make_internationalized_list,
     number,
     same_device,
     stdchannel_redirected,
 )
+
+install_gettext()
 
 DownloadingTo = defaultdict[int, set[FileType]]
 

--- a/raphodo/downloadtracker.py
+++ b/raphodo/downloadtracker.py
@@ -8,8 +8,11 @@ import time
 from collections import defaultdict
 
 from raphodo.constants import DownloadStatus, DownloadUpdateSeconds, FileType
+from raphodo.internationalisation.install import install_gettext
 from raphodo.rpdfile import RPDFile
 from raphodo.thumbnaildisplay import DownloadStats
+
+install_gettext()
 
 
 class DownloadTracker:

--- a/raphodo/errorlog.py
+++ b/raphodo/errorlog.py
@@ -51,9 +51,12 @@ from PyQt5.QtWidgets import (
 from showinfm import show_in_file_manager
 
 from raphodo.constants import ErrorType
+from raphodo.internationalisation.install import install_gettext
 from raphodo.problemnotification import Problem, Problems
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.viewutils import darkModeIcon, translateDialogBoxButtons
+
+install_gettext()
 
 
 class QFindLineEdit(QLineEdit):

--- a/raphodo/excepthook.py
+++ b/raphodo/excepthook.py
@@ -16,11 +16,14 @@ except Exception:
     # if import failed for any reason, ignore it
     have_easygui = False
 
+from raphodo.internationalisation.install import install_gettext
 from raphodo.iplogging import full_log_file_path
 from raphodo.prefs.preferences import Preferences
 from raphodo.storage.storage import get_uri
 from raphodo.tools.utilities import bug_report_full_tar_path, create_bugreport_tar
 from raphodo.ui.viewutils import standardMessageBox
+
+install_gettext()
 
 message_box_displayed = False
 exceptions_notified = set()

--- a/raphodo/generatename.py
+++ b/raphodo/generatename.py
@@ -13,7 +13,6 @@ with contextlib.suppress(locale.Error):
     # Use the default locale as defined by the LANG variable
     locale.setlocale(locale.LC_ALL, "")
 
-
 from raphodo.generatenameconfig import (
     APERTURE,
     ARTIST,
@@ -69,6 +68,7 @@ from raphodo.generatenameconfig import (
     YESTERDAY,
     PrefValueInvalidError,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import DownloadsTodayTracker
 from raphodo.problemnotification import (
     FilenameNotFullyGeneratedProblem,
@@ -79,6 +79,8 @@ from raphodo.problemnotification import (
 from raphodo.rpdfile import RPDFile
 from raphodo.storage.storage import get_uri
 from raphodo.tools.utilities import letters
+
+install_gettext()
 
 MatchedSequences = namedtuple(
     "MatchedSequences",

--- a/raphodo/generatenameconfig.py
+++ b/raphodo/generatenameconfig.py
@@ -4,6 +4,10 @@
 import os
 from collections import OrderedDict
 
+from raphodo.internationalisation.install import install_gettext
+
+install_gettext()
+
 PrefList = list[str]
 CustomPresetSubfolderNames = tuple[tuple[str]]
 CustomPresetSubfolderLists = tuple[list[str]]

--- a/raphodo/internationalisation/install.py
+++ b/raphodo/internationalisation/install.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright 2016-2024 Damon Lynch <damonlynch@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Initialize gettext translations.
+"""
+
+import builtins
+import gettext
+import locale
+import os
+import sys
+from pathlib import Path
+
+try:
+    from PyQt5.QtCore import QSettings
+
+    have_pyqt = True
+except ImportError:
+    have_pyqt = False
+
+i18n_domain = "rapid-photo-downloader"
+localedir = Path(__file__).parent.parent / "locale"
+if not Path(localedir).is_dir():
+    print(f"{localedir} does not exist", file=sys.stderr)
+
+
+def sample_translation() -> str:
+    """
+    :return: return the Spanish translation as a sample translation
+    """
+
+    mo_file = f"{i18n_domain}.mo"
+    return os.path.join("es", "LC_MESSAGES", mo_file)
+
+
+def no_translation_performed(s: str) -> str:
+    """
+    We are missing translation mo files. Do nothing but return the string
+    """
+
+    return s
+
+
+def install_gettext() -> None:
+    """
+    Install translation support
+    Users and specify the translation they want in the program preferences
+    The default is to use the system default
+    """
+
+    if "_" in builtins.__dict__:
+        return
+
+    lang_installed = False
+
+    if (
+        have_pyqt
+        and localedir is not None
+        and os.path.isfile(os.path.join(localedir, sample_translation()))
+    ):
+        settings = QSettings("Rapid Photo Downloader", "Rapid Photo Downloader")
+        settings.beginGroup("Display")
+        lang = settings.value("language", "", str)
+        settings.endGroup()
+
+        if not lang:
+            lang, encoding = locale.getdefaultlocale()
+
+        try:
+            gnulang = gettext.translation(
+                i18n_domain, localedir=localedir, languages=[lang]
+            )
+            gnulang.install()
+            lang_installed = True
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+    if not lang_installed:
+        # Building on what lang.install() does above - but in this case, pretend we are
+        # translating files
+        builtins.__dict__["_"] = no_translation_performed

--- a/raphodo/internationalisation/utilities.py
+++ b/raphodo/internationalisation/utilities.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright 2007-2024 Damon Lynch <damonlynch@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import locale
+
+
+def make_internationalized_list(items: list[str]) -> str:
+    r"""
+    Makes a string of items conforming to i18n
+
+    >>> print(make_internationalized_list([]))
+    <BLANKLINE>
+    >>> print(make_internationalized_list(['one']))
+    one
+    >>> print(make_internationalized_list(['one', 'two']))
+    one and two
+    >>> print(make_internationalized_list(['one', 'two', 'three']))
+    one, two and three
+    >>> print(make_internationalized_list(['one', 'two', 'three', 'four']))
+    one, two, three and four
+
+    Loosely follows the guideline here:
+    http://cldr.unicode.org/translation/lists
+
+    :param items: the list of items to make a string out of
+    :return: internationalized string
+    """
+
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        # Translators: two things in a list e.g. "device1 and device2"
+        # Translators: %(variable)s represents Python code, not a plural of the term
+        # variable. You must keep the %(variable)s untranslated, or the program will
+        # crash.
+        return _("%(first_item)s and %(last_item)s") % dict(
+            first_item=items[0], last_item=items[1]
+        )
+    if len(items) > 2:
+        s = items[0]
+        for item in items[1:-1]:
+            # Translators: the middle of a list of things,
+            # e.g, 'camera, memory card'
+            # Translators: %(variable)s represents Python code, not a plural of the term
+            # variable. You must keep the %(variable)s untranslated, or the program will
+            # crash.
+            s = _("%(first_items)s, %(last_items)s") % dict(
+                first_items=s, last_items=item
+            )
+        # Translators: the end of a list of things,
+        # e.g, 'camera, memory card and external drive'
+        # where 'camera, memory card' are represented by start_items in the code
+        # and 'external drive' is represented by last_item in the code
+        # Translators: %(variable)s represents Python code, not a plural of the term
+        # variable. You must keep the %(variable)s untranslated, or the program will
+        # crash.
+        s = _("%(start_items)s and %(last_item)s") % dict(
+            start_items=s, last_item=items[-1]
+        )
+        return s
+    return ""
+
+
+def thousands(i: int) -> str:
+    """
+    Add a thousands separator (or its locale equivalent) to an
+    integer. Assumes the module level locale setting has already been
+    set.
+    :param i: the integer e.g., 1000
+    :return: string with seperators e.g. '1,000'
+    """
+    try:
+        return locale.format_string("%d", i, grouping=True)
+    except TypeError:
+        return str(i)

--- a/raphodo/metadata/analysis/analyzephotos.py
+++ b/raphodo/metadata/analysis/analyzephotos.py
@@ -41,10 +41,12 @@ from raphodo.metadata.analysis.photoattributes import (
 )
 from raphodo.metadata.analysis.videoattributes import VideoAttributes
 from raphodo.metadata.exiftool import ExifTool
-from raphodo.metadata.fileformats import (
+from raphodo.metadata.fileextensions import (
     JPEG_TYPE_EXTENSIONS,
     RAW_EXTENSIONS,
     VIDEO_EXTENSIONS,
+)
+from raphodo.metadata.fileformats import (
     extract_extension,
     use_exiftool_on_photo,
 )

--- a/raphodo/metadata/fileextensions.py
+++ b/raphodo/metadata/fileextensions.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright 2011-2024 Damon Lynch <damonlynch@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from raphodo.constants import thumbnail_offset
+
+RAW_EXTENSIONS = [
+    "3fr",
+    "arw",
+    "dcr",
+    "cr2",
+    "crw",
+    "dng",
+    "fff",
+    "iiq",
+    "mos",
+    "mef",
+    "mrw",
+    "nef",
+    "nrw",
+    "orf",
+    "ori",
+    "pef",
+    "raf",
+    "raw",
+    "rw2",
+    "sr2",
+    "srw",
+    "x3f",
+]
+HEIF_EXTENTIONS = ["heif", "heic", "hif"]
+EXIFTOOL_ONLY_EXTENSIONS_STRINGS_AND_PREVIEWS = ["mos", "mrw", "x3f"]
+JPEG_EXTENSIONS = ["jpg", "jpe", "jpeg"]
+JPEG_TYPE_EXTENSIONS = ["jpg", "jpe", "jpeg", "mpo"]
+OTHER_PHOTO_EXTENSIONS = ["tif", "tiff", "mpo"]
+NON_RAW_IMAGE_EXTENSIONS = JPEG_EXTENSIONS + OTHER_PHOTO_EXTENSIONS
+PHOTO_EXTENSIONS = RAW_EXTENSIONS + NON_RAW_IMAGE_EXTENSIONS
+PHOTO_EXTENSIONS_WITHOUT_OTHER = RAW_EXTENSIONS + JPEG_EXTENSIONS
+PHOTO_EXTENSIONS_SCAN = PHOTO_EXTENSIONS
+AUDIO_EXTENSIONS = ["wav", "mp3"]
+VIDEO_EXTENSIONS = [
+    "3gp",
+    "avi",
+    "lrv",
+    "m2t",
+    "m2ts",
+    "mov",
+    "mp4",
+    "mpeg",
+    "mpg",
+    "mod",
+    "tod",
+    "mts",
+]
+VIDEO_THUMBNAIL_EXTENSIONS = ["thm"]
+ALL_USER_VISIBLE_EXTENSIONS = PHOTO_EXTENSIONS + VIDEO_EXTENSIONS + ["xmp", "log"]
+ALL_KNOWN_EXTENSIONS = (
+    ALL_USER_VISIBLE_EXTENSIONS + AUDIO_EXTENSIONS + VIDEO_THUMBNAIL_EXTENSIONS
+)
+MUST_CACHE_VIDEOS = [
+    video for video in VIDEO_EXTENSIONS if thumbnail_offset.get(video) is None
+]

--- a/raphodo/metadata/fileformats.py
+++ b/raphodo/metadata/fileformats.py
@@ -8,7 +8,17 @@ import subprocess
 from packaging.version import parse as parse_version
 
 import raphodo.programversions as programversions
-from raphodo.constants import FileExtension, FileType, thumbnail_offset
+from raphodo.constants import FileExtension, FileType
+from raphodo.metadata.fileextensions import (
+    AUDIO_EXTENSIONS,
+    EXIFTOOL_ONLY_EXTENSIONS_STRINGS_AND_PREVIEWS,
+    HEIF_EXTENTIONS,
+    JPEG_EXTENSIONS,
+    OTHER_PHOTO_EXTENSIONS,
+    PHOTO_EXTENSIONS_SCAN,
+    RAW_EXTENSIONS,
+    VIDEO_EXTENSIONS,
+)
 
 
 def exiftool_capabilities() -> tuple[bool, bool]:
@@ -58,90 +68,18 @@ def heif_capable() -> bool:
     return _exiftool_heif
 
 
-RAW_EXTENSIONS = [
-    "3fr",
-    "arw",
-    "dcr",
-    "cr2",
-    "crw",
-    "dng",
-    "fff",
-    "iiq",
-    "mos",
-    "mef",
-    "mrw",
-    "nef",
-    "nrw",
-    "orf",
-    "ori",
-    "pef",
-    "raf",
-    "raw",
-    "rw2",
-    "sr2",
-    "srw",
-    "x3f",
-]
-
-HEIF_EXTENTIONS = ["heif", "heic", "hif"]
-
 if cr3_capable():
     RAW_EXTENSIONS.append("cr3")
 
 RAW_EXTENSIONS.sort()
 
-EXIFTOOL_ONLY_EXTENSIONS_STRINGS_AND_PREVIEWS = ["mos", "mrw", "x3f"]
-
 if not _exiv2_cr3 and _exiftool_cr3:
     EXIFTOOL_ONLY_EXTENSIONS_STRINGS_AND_PREVIEWS.append("cr3")
-
-JPEG_EXTENSIONS = ["jpg", "jpe", "jpeg"]
-
-JPEG_TYPE_EXTENSIONS = ["jpg", "jpe", "jpeg", "mpo"]
-
-OTHER_PHOTO_EXTENSIONS = ["tif", "tiff", "mpo"]
 
 if heif_capable():
     OTHER_PHOTO_EXTENSIONS.extend(HEIF_EXTENTIONS)
 
-NON_RAW_IMAGE_EXTENSIONS = JPEG_EXTENSIONS + OTHER_PHOTO_EXTENSIONS
-
-PHOTO_EXTENSIONS = RAW_EXTENSIONS + NON_RAW_IMAGE_EXTENSIONS
-
-PHOTO_EXTENSIONS_WITHOUT_OTHER = RAW_EXTENSIONS + JPEG_EXTENSIONS
-
-PHOTO_EXTENSIONS_SCAN = PHOTO_EXTENSIONS
-
-AUDIO_EXTENSIONS = ["wav", "mp3"]
-
-VIDEO_EXTENSIONS = [
-    "3gp",
-    "avi",
-    "lrv",
-    "m2t",
-    "m2ts",
-    "mov",
-    "mp4",
-    "mpeg",
-    "mpg",
-    "mod",
-    "tod",
-    "mts",
-]
-
 VIDEO_EXTENSIONS.sort()
-
-VIDEO_THUMBNAIL_EXTENSIONS = ["thm"]
-
-ALL_USER_VISIBLE_EXTENSIONS = PHOTO_EXTENSIONS + VIDEO_EXTENSIONS + ["xmp", "log"]
-
-ALL_KNOWN_EXTENSIONS = (
-    ALL_USER_VISIBLE_EXTENSIONS + AUDIO_EXTENSIONS + VIDEO_THUMBNAIL_EXTENSIONS
-)
-
-MUST_CACHE_VIDEOS = [
-    video for video in VIDEO_EXTENSIONS if thumbnail_offset.get(video) is None
-]
 
 
 def use_exiftool_on_photo(extension: str, preview_extraction_irrelevant: bool) -> bool:

--- a/raphodo/prefs/preferencedialog.py
+++ b/raphodo/prefs/preferencedialog.py
@@ -54,7 +54,11 @@ from raphodo.constants import (
     MarkRawJpeg,
     TreatRawJpeg,
 )
-from raphodo.metadata.fileformats import (
+from raphodo.internationalisation.utilities import (
+    make_internationalized_list,
+    thousands,
+)
+from raphodo.metadata.fileextensions import (
     ALL_KNOWN_EXTENSIONS,
     AUDIO_EXTENSIONS,
     PHOTO_EXTENSIONS,
@@ -68,8 +72,6 @@ from raphodo.tools.utilities import (
     current_version_is_dev_version,
     data_file_path,
     format_size_for_user,
-    make_internationalized_list,
-    thousands,
 )
 from raphodo.ui.viewutils import (
     QNarrowListWidget,

--- a/raphodo/prefs/preferences.py
+++ b/raphodo/prefs/preferences.py
@@ -38,7 +38,9 @@ from raphodo.generatenameconfig import (
     check_pref_valid,
     upgrade_pre090a4_rename_pref,
 )
-from raphodo.metadata.fileformats import ALL_KNOWN_EXTENSIONS
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import make_internationalized_list
+from raphodo.metadata.fileextensions import ALL_KNOWN_EXTENSIONS
 from raphodo.storage.storage import (
     get_media_dir,
     platform_photos_directory,
@@ -49,8 +51,9 @@ from raphodo.storage.storage import (
 from raphodo.tools.utilities import (
     available_cpu_count,
     default_thumbnail_process_count,
-    make_internationalized_list,
 )
+
+install_gettext()
 
 
 class ScanPreferences:

--- a/raphodo/problemnotification.py
+++ b/raphodo/problemnotification.py
@@ -27,7 +27,7 @@ from html import escape
 
 from raphodo.camera import gphoto2_named_error
 from raphodo.constants import ErrorType
-from raphodo.tools.utilities import make_internationalized_list
+from raphodo.internationalisation.utilities import make_internationalized_list
 
 
 def make_href(name: str, uri: str) -> str:

--- a/raphodo/proximity.py
+++ b/raphodo/proximity.py
@@ -78,6 +78,7 @@ from raphodo.constants import (
     fileTypeColor,
     proximity_time_steps,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import Preferences
 from raphodo.rpdfile import FileTypeCounter
 from raphodo.tools.timeutils import (
@@ -96,6 +97,8 @@ from raphodo.ui.viewutils import (
     darkModePixmap,
     is_dark_mode,
 )
+
+install_gettext()
 
 ProximityRow = namedtuple(
     "ProximityRow",

--- a/raphodo/rapid.py
+++ b/raphodo/rapid.py
@@ -167,6 +167,7 @@ from raphodo.devices import (
     FSMetadataErrors,
 )
 from raphodo.errorlog import ErrorReport, SpeechBubble
+from raphodo.metadata.fileextensions import PHOTO_EXTENSIONS, VIDEO_EXTENSIONS
 from raphodo.filesystemurl import FileSystemUrlHandler
 from raphodo.folderpreviewmanager import FolderPreviewManager
 from raphodo.generatenameconfig import (
@@ -175,6 +176,11 @@ from raphodo.generatenameconfig import (
     upgrade_pre090a4_rename_pref,
 )
 from raphodo.heif import have_heif_module, libheif_version, pyheif_version
+from raphodo.internationalisation.install import install_gettext, localedir
+from raphodo.internationalisation.utilities import (
+    make_internationalized_list,
+    thousands,
+)
 from raphodo.interprocess import (
     BackupArguments,
     BackupFileData,
@@ -286,18 +292,18 @@ from raphodo.tools.utilities import (
     installed_using_pip,
     log_os_release,
     make_html_path_non_breaking,
-    make_internationalized_list,
     pref_bool_from_gconftool2_string,
     prefs_list_from_gconftool2_string,
     process_running,
     same_device,
-    thousands,
 )
 from raphodo.wsl.wsl import (
     WindowsDriveMount,
     WslDrives,
     WslWindowsRemovableDriveMonitor,
 )
+
+install_gettext()
 
 # Avoid segfaults at exit:
 # http://pyqt.sourceforge.net/Docs/PyQt5/gotchas.html#crashes-on-exit
@@ -842,7 +848,7 @@ class RapidWindow(QMainWindow):
                 logging.error("Notification intialization problem")
                 self.have_libnotify = False
 
-        logging.debug("Locale directory: %s", raphodo.localedir)
+        logging.debug("Locale directory: %s", localedir)
 
         logging.debug("Probing for valid mounts")
         self.validMounts = ValidMounts(
@@ -6894,8 +6900,8 @@ def main():
         sys.exit(0)
 
     if args.extensions:
-        photos = list(ext.upper() for ext in fileformats.PHOTO_EXTENSIONS)
-        videos = list(ext.upper() for ext in fileformats.VIDEO_EXTENSIONS)
+        photos = list(ext.upper() for ext in PHOTO_EXTENSIONS)
+        videos = list(ext.upper() for ext in VIDEO_EXTENSIONS)
         extensions = ((photos, _("Photos")), (videos, _("Videos")))
         for exts, file_type in extensions:
             extensions = make_internationalized_list(exts)

--- a/raphodo/renameandmovefile.py
+++ b/raphodo/renameandmovefile.py
@@ -31,6 +31,7 @@ from raphodo.constants import (
     FileType,
     RenameAndMoveStatus,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.interprocess import (
     DaemonProcess,
     RenameAndMoveFileData,
@@ -58,6 +59,8 @@ from raphodo.tools.utilities import (
     platform_c_maxint,
     stdchannel_redirected,
 )
+
+install_gettext()
 
 
 class SyncRawJpegStatus(Enum):

--- a/raphodo/rpdfile.py
+++ b/raphodo/rpdfile.py
@@ -18,6 +18,7 @@ gi.require_version("GLib", "2.0")
 from gi.repository import GLib
 
 import raphodo.metadata.exiftool as exiftool
+import raphodo.metadata.fileextensions
 import raphodo.metadata.fileformats as fileformats
 import raphodo.metadata.metadataexiftool as metadataexiftool
 import raphodo.metadata.metadataphoto as metadataphoto
@@ -33,13 +34,18 @@ from raphodo.constants import (
     ThumbnailCacheDiskStatus,
     ThumbnailCacheStatus,
 )
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import (
+    make_internationalized_list,
+    thousands,
+)
 from raphodo.problemnotification import Problem, make_href
 from raphodo.storage.storage import CameraDetails, get_uri
 from raphodo.tools.utilities import (
     datetime_roughly_equal,
-    make_internationalized_list,
-    thousands,
 )
+
+install_gettext()
 
 
 def get_sort_priority(
@@ -710,14 +716,14 @@ class RPDFile:
 
         :return: True if the image is a RAW file
         """
-        return self.extension in fileformats.RAW_EXTENSIONS
+        return self.extension in raphodo.metadata.fileextensions.RAW_EXTENSIONS
 
     def is_heif(self) -> bool:
         """
         Inspects file extension to determine if an HEIF / HEIC file
         :return:
         """
-        return self.extension in fileformats.HEIF_EXTENTIONS
+        return self.extension in raphodo.metadata.fileextensions.HEIF_EXTENTIONS
 
     def is_tiff(self) -> bool:
         """

--- a/raphodo/scan.py
+++ b/raphodo/scan.py
@@ -38,6 +38,8 @@ from collections import defaultdict, deque, namedtuple
 from collections.abc import Iterator
 from datetime import datetime
 
+import raphodo.metadata.fileextensions
+
 with contextlib.suppress(locale.Error):
     # Use the default locale as defined by the LANG variable
     locale.setlocale(locale.LC_ALL, "")
@@ -208,8 +210,8 @@ class ScanWorker(WorkerInPublishPullPipeline):
             self.gphoto2_logging = gphoto2_python_logging()
 
         if scan_arguments.ignore_other_types:
-            fileformats.PHOTO_EXTENSIONS_SCAN = (
-                fileformats.PHOTO_EXTENSIONS_WITHOUT_OTHER
+            raphodo.metadata.fileextensions.PHOTO_EXTENSIONS_SCAN = (
+                raphodo.metadata.fileextensions.PHOTO_EXTENSIONS_WITHOUT_OTHER
             )
 
         self.device = scan_arguments.device
@@ -783,9 +785,12 @@ class ScanWorker(WorkerInPublishPullPipeline):
                         )
             else:
                 # this file on the camera is not a photo or video
-                if ext_lower in fileformats.AUDIO_EXTENSIONS:
+                if ext_lower in raphodo.metadata.fileextensions.AUDIO_EXTENSIONS:
                     self._camera_audio_files[base_name].append((path, ext))
-                elif ext_lower in fileformats.VIDEO_THUMBNAIL_EXTENSIONS:
+                elif (
+                    ext_lower
+                    in raphodo.metadata.fileextensions.VIDEO_THUMBNAIL_EXTENSIONS
+                ):
                     self._camera_video_thumbnails[base_name].append((path, ext))
                 elif ext_lower == "xmp":
                     self._camera_xmp_files[base_name].append((path, ext))
@@ -1821,7 +1826,7 @@ class ScanWorker(WorkerInPublishPullPipeline):
             )
         else:
             return self._get_associate_file(
-                base_name, fileformats.VIDEO_THUMBNAIL_EXTENSIONS
+                base_name, raphodo.metadata.fileextensions.VIDEO_THUMBNAIL_EXTENSIONS
             )
 
     def get_audio_file(self, base_name: str, camera_file: CameraFile) -> str | None:
@@ -1838,7 +1843,9 @@ class ScanWorker(WorkerInPublishPullPipeline):
                 base_name, self._camera_audio_files, camera_file
             )
         else:
-            return self._get_associate_file(base_name, fileformats.AUDIO_EXTENSIONS)
+            return self._get_associate_file(
+                base_name, raphodo.metadata.fileextensions.AUDIO_EXTENSIONS
+            )
 
     def get_log_file(self, base_name: str, camera_file: CameraFile) -> str | None:
         """

--- a/raphodo/storage/storage.py
+++ b/raphodo/storage/storage.py
@@ -45,6 +45,12 @@ from urllib.parse import quote
 from urllib.request import pathname2url
 
 import gi
+
+gi.require_version("GUdev", "1.0")
+gi.require_version("UDisks", "2.0")
+gi.require_version("GExiv2", "0.10")
+gi.require_version("GLib", "2.0")
+from gi.repository import GLib, GUdev, UDisks
 from PyQt5.QtCore import (
     QFileSystemWatcher,
     QObject,
@@ -57,6 +63,12 @@ from PyQt5.QtCore import (
 from showinfm import LinuxDesktop, linux_desktop, valid_file_manager
 from tenacity import retry, stop_after_attempt, wait_fixed
 
+from raphodo.constants import Distro, PostCameraUnmountAction
+from raphodo.internationalisation.install import install_gettext
+from raphodo.tools.utilities import (
+    log_os_release,
+    remove_topmost_directory_from_path,
+)
 from raphodo.wsl.wslutils import (
     wsl_conf_mnt_location,
     wsl_filter_directories,
@@ -65,17 +77,7 @@ from raphodo.wsl.wslutils import (
     wsl_videos_folder,
 )
 
-gi.require_version("GUdev", "1.0")
-gi.require_version("UDisks", "2.0")
-gi.require_version("GExiv2", "0.10")
-gi.require_version("GLib", "2.0")
-from gi.repository import GLib, GUdev, UDisks
-
-from raphodo.constants import Distro, PostCameraUnmountAction
-from raphodo.tools.utilities import (
-    log_os_release,
-    remove_topmost_directory_from_path,
-)
+install_gettext()
 
 logging_level = logging.DEBUG
 

--- a/raphodo/sudocommand.py
+++ b/raphodo/sudocommand.py
@@ -21,9 +21,12 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
+from raphodo.internationalisation.install import install_gettext
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.password import PasswordEdit
 from raphodo.ui.viewutils import translateDialogBoxButtons
+
+install_gettext()
 
 
 class SudoCommand(QDialog):

--- a/raphodo/thumbnaildisplay.py
+++ b/raphodo/thumbnaildisplay.py
@@ -81,10 +81,12 @@ from raphodo.constants import (
     manually_marked_previously_downloaded,
     thumbnail_margin,
 )
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import make_internationalized_list
 from raphodo.interprocess import (
     Device,
 )
-from raphodo.metadata.fileformats import ALL_USER_VISIBLE_EXTENSIONS
+from raphodo.metadata.fileextensions import ALL_USER_VISIBLE_EXTENSIONS
 from raphodo.prefs.preferences import Preferences  # noqa: F401
 from raphodo.proximity import TemporalProximityState
 from raphodo.rpdfile import FileTypeCounter, RPDFile
@@ -100,7 +102,6 @@ from raphodo.tools.utilities import (
     arrow_locale,
     data_file_path,
     format_size_for_user,
-    make_internationalized_list,
     runs,
 )
 from raphodo.ui.viewutils import (
@@ -109,6 +110,8 @@ from raphodo.ui.viewutils import (
     is_dark_mode,
     scaledIcon,
 )
+
+install_gettext()
 
 
 class DownloadStats:

--- a/raphodo/tools/utilities.py
+++ b/raphodo/tools/utilities.py
@@ -29,7 +29,9 @@ from packaging.version import parse
 from PyQt5.QtCore import QLibraryInfo, QSize, QStandardPaths, QTranslator
 
 import raphodo.__about__ as __about__
-from raphodo import i18n_domain, localedir
+from raphodo.internationalisation.install import i18n_domain, install_gettext, localedir
+
+install_gettext()
 
 # Linux specific code to ensure child processes exit when parent dies
 # See http://stackoverflow.com/questions/19447603/
@@ -410,77 +412,6 @@ def find_mount_point(path: str) -> str:
     while not os.path.ismount(path):
         path = os.path.dirname(path)
     return path
-
-
-def make_internationalized_list(items: list[str]) -> str:
-    r"""
-    Makes a string of items conforming to i18n
-
-    >>> print(make_internationalized_list([]))
-    <BLANKLINE>
-    >>> print(make_internationalized_list(['one']))
-    one
-    >>> print(make_internationalized_list(['one', 'two']))
-    one and two
-    >>> print(make_internationalized_list(['one', 'two', 'three']))
-    one, two and three
-    >>> print(make_internationalized_list(['one', 'two', 'three', 'four']))
-    one, two, three and four
-
-    Loosely follows the guideline here:
-    http://cldr.unicode.org/translation/lists
-
-    :param items: the list of items to make a string out of
-    :return: internationalized string
-    """
-
-    if len(items) == 1:
-        return items[0]
-    if len(items) == 2:
-        # Translators: two things in a list e.g. "device1 and device2"
-        # Translators: %(variable)s represents Python code, not a plural of the term
-        # variable. You must keep the %(variable)s untranslated, or the program will
-        # crash.
-        return _("%(first_item)s and %(last_item)s") % dict(
-            first_item=items[0], last_item=items[1]
-        )
-    if len(items) > 2:
-        s = items[0]
-        for item in items[1:-1]:
-            # Translators: the middle of a list of things,
-            # e.g, 'camera, memory card'
-            # Translators: %(variable)s represents Python code, not a plural of the term
-            # variable. You must keep the %(variable)s untranslated, or the program will
-            # crash.
-            s = _("%(first_items)s, %(last_items)s") % dict(
-                first_items=s, last_items=item
-            )
-        # Translators: the end of a list of things,
-        # e.g, 'camera, memory card and external drive'
-        # where 'camera, memory card' are represented by start_items in the code
-        # and 'external drive' is represented by last_item in the code
-        # Translators: %(variable)s represents Python code, not a plural of the term
-        # variable. You must keep the %(variable)s untranslated, or the program will
-        # crash.
-        s = _("%(start_items)s and %(last_item)s") % dict(
-            start_items=s, last_item=items[-1]
-        )
-        return s
-    return ""
-
-
-def thousands(i: int) -> str:
-    """
-    Add a thousands separator (or its locale equivalent) to an
-    integer. Assumes the module level locale setting has already been
-    set.
-    :param i: the integer e.g., 1000
-    :return: string with seperators e.g. '1,000'
-    """
-    try:
-        return locale.format_string("%d", i, grouping=True)
-    except TypeError:
-        return str(i)
 
 
 # Source of class AdjacentKey, first_and_last and runs:

--- a/raphodo/ui/aboutdialog.py
+++ b/raphodo/ui/aboutdialog.py
@@ -24,8 +24,11 @@ from PyQt5.QtWidgets import (
 )
 
 import raphodo.__about__ as __about__
+from raphodo.internationalisation.install import install_gettext
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.viewutils import translateDialogBoxButtons
+
+install_gettext()
 
 
 class AboutDialog(QDialog):

--- a/raphodo/ui/backuppanel.py
+++ b/raphodo/ui/backuppanel.py
@@ -48,6 +48,7 @@ from raphodo.devices import (
     BackupVolumeDetails,
     DownloadingTo,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import Preferences
 from raphodo.rpdfile import FileTypeCounter
 from raphodo.storage.storage import ValidMounts, get_media_dir, get_mount_size
@@ -61,6 +62,8 @@ from raphodo.ui.viewutils import (
     RowTracker,
     ScrollAreaNoFrame,
 )
+
+install_gettext()
 
 
 class BackupVolumeUse(NamedTuple):

--- a/raphodo/ui/destinationdisplay.py
+++ b/raphodo/ui/destinationdisplay.py
@@ -58,9 +58,10 @@ from raphodo.generatenameconfig import (
     CustomPresetSubfolderLists,
     CustomPresetSubfolderNames,
 )
+from raphodo.internationalisation.utilities import thousands
 from raphodo.rpdfile import FileTypeCounter, Photo, Video
 from raphodo.storage.storage import StorageSpace, get_mount_size, get_path_display_name
-from raphodo.tools.utilities import data_file_path, format_size_for_user, thousands
+from raphodo.tools.utilities import data_file_path, format_size_for_user
 from raphodo.ui.devicedisplay import BodyDetails, DeviceDisplay, icon_size
 from raphodo.ui.nameeditor import PrefDialog, make_subfolder_menu_entry
 from raphodo.ui.viewutils import darkModePixmap, paletteMidPen

--- a/raphodo/ui/destinationpanel.py
+++ b/raphodo/ui/destinationpanel.py
@@ -9,6 +9,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QSplitter, QVBoxLayout, QWidget
 
 from raphodo.devices import DownloadingTo
+from raphodo.internationalisation.install import install_gettext
 from raphodo.rpdfile import FileType
 from raphodo.thumbnaildisplay import MarkedSummary
 from raphodo.ui.computerview import ComputerWidget
@@ -19,6 +20,8 @@ from raphodo.ui.destinationdisplay import (
 )
 from raphodo.ui.panelview import QPanelView
 from raphodo.ui.viewutils import ScrollAreaNoFrame
+
+install_gettext()
 
 
 class DestinationPanel(ScrollAreaNoFrame):

--- a/raphodo/ui/devicedisplay.py
+++ b/raphodo/ui/devicedisplay.py
@@ -82,9 +82,11 @@ from raphodo.constants import (
     ViewRowType,
 )
 from raphodo.devices import Device
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import thousands
 from raphodo.rpdfile import make_key
 from raphodo.storage.storage import StorageSpace
-from raphodo.tools.utilities import data_file_path, format_size_for_user, thousands
+from raphodo.tools.utilities import data_file_path, format_size_for_user
 from raphodo.ui.viewutils import (
     ListViewFlexiFrame,
     RowTracker,
@@ -94,6 +96,8 @@ from raphodo.ui.viewutils import (
     scaledIcon,
     standard_font_size,
 )
+
+install_gettext()
 
 
 def icon_size() -> int:

--- a/raphodo/ui/didyouknow.py
+++ b/raphodo/ui/didyouknow.py
@@ -27,9 +27,12 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import Preferences
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.viewutils import translateDialogBoxButtons
+
+install_gettext()
 
 tips = (
     (

--- a/raphodo/ui/filebrowse.py
+++ b/raphodo/ui/filebrowse.py
@@ -41,6 +41,7 @@ from raphodo.constants import (
     minPanelWidth,
     non_system_root_folders,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.storage.storage import get_media_dir, gvfs_gphoto2_path
 from raphodo.ui.viewutils import (
     TopFramedVerticalScrollBar,
@@ -48,6 +49,8 @@ from raphodo.ui.viewutils import (
     standard_font_size,
 )
 from raphodo.wsl.wslutils import wsl_filter_directories
+
+install_gettext()
 
 
 class FileSystemModel(QFileSystemModel):

--- a/raphodo/ui/foldercombo.py
+++ b/raphodo/ui/foldercombo.py
@@ -17,6 +17,7 @@ from raphodo.constants import (
     StandardFileLocations,
     max_remembered_destinations,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import Preferences
 from raphodo.storage.storage import (
     ValidMounts,
@@ -25,6 +26,8 @@ from raphodo.storage.storage import (
     platform_videos_directory,
 )
 from raphodo.tools.utilities import data_file_path, make_path_end_snippets_unique
+
+install_gettext()
 
 
 class FolderCombo(QComboBox):

--- a/raphodo/ui/jobcodepanel.py
+++ b/raphodo/ui/jobcodepanel.py
@@ -31,6 +31,7 @@ from PyQt5.QtWidgets import (
 )
 
 from raphodo.constants import JobCodeSort
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import Preferences
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.chevroncombo import ChevronCombo
@@ -44,6 +45,8 @@ from raphodo.ui.viewutils import (
     standardMessageBox,
     translateDialogBoxButtons,
 )
+
+install_gettext()
 
 
 class JobCodeDialog(QDialog):

--- a/raphodo/ui/messagewidget.py
+++ b/raphodo/ui/messagewidget.py
@@ -9,6 +9,10 @@ from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QFocusEvent, QMouseEvent
 from PyQt5.QtWidgets import QLabel, QPushButton, QSizePolicy, QStackedWidget
 
+from raphodo.internationalisation.install import install_gettext
+
+install_gettext()
+
 
 class MessageWidget(QStackedWidget):
     """

--- a/raphodo/ui/nameeditor.py
+++ b/raphodo/ui/nameeditor.py
@@ -78,6 +78,7 @@ from raphodo.generatenameconfig import (
     VIDEO_SUBFOLDER_MENU_DEFAULTS_CONV,
     filter_subfolder_prefs,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import (
     DownloadsTodayTracker,
     Preferences,
@@ -91,6 +92,8 @@ from raphodo.ui.viewutils import (
     translateDialogBoxButtons,
     translateMessageBoxButtons,
 )
+
+install_gettext()
 
 
 class PrefEditor(QTextEdit):

--- a/raphodo/ui/panelview.py
+++ b/raphodo/ui/panelview.py
@@ -18,7 +18,10 @@ from raphodo.constants import (
     HeaderBackgroundName,
     minPanelWidth,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.ui.viewutils import is_dark_mode
+
+install_gettext()
 
 
 class QPanelView(QWidget):

--- a/raphodo/ui/primarybutton.py
+++ b/raphodo/ui/primarybutton.py
@@ -14,8 +14,11 @@ from PyQt5.QtGui import (
 )
 from PyQt5.QtWidgets import QApplication, QPushButton, QSizePolicy
 
+from raphodo.internationalisation.install import install_gettext
 from raphodo.ui.rotatedpushbutton import FlatButton
 from raphodo.ui.viewutils import darkModeIcon, is_dark_mode
+
+install_gettext()
 
 
 class TopPushButton(QPushButton, FlatButton):

--- a/raphodo/ui/rememberthisdialog.py
+++ b/raphodo/ui/rememberthisdialog.py
@@ -11,8 +11,11 @@ from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QGridLayout, QLabel
 
 from raphodo.constants import RememberThisButtons, RememberThisMessage
+from raphodo.internationalisation.install import install_gettext
 from raphodo.tools.utilities import data_file_path
 from raphodo.ui.viewutils import standardIconSize, translateDialogBoxButtons
+
+install_gettext()
 
 
 class RememberThisDialog(QDialog):

--- a/raphodo/ui/renamepanel.py
+++ b/raphodo/ui/renamepanel.py
@@ -31,12 +31,15 @@ from raphodo.generatenameconfig import (
     UPPERCASE,
     VIDEO_RENAME_MENU_DEFAULTS_CONV,
 )
+from raphodo.internationalisation.install import install_gettext
 from raphodo.prefs.preferences import DownloadsTodayTracker, Preferences
 from raphodo.rpdfile import Photo, Video
 from raphodo.tools.utilities import platform_c_maxint
 from raphodo.ui.nameeditor import PrefDialog, PresetComboBox, make_sample_rpd_file
 from raphodo.ui.panelview import QPanelView
 from raphodo.ui.viewutils import FlexiFrame, ScrollAreaNoFrame
+
+install_gettext()
 
 
 class RenameWidget(FlexiFrame):

--- a/raphodo/ui/rotatedpushbutton.py
+++ b/raphodo/ui/rotatedpushbutton.py
@@ -12,7 +12,10 @@ from PyQt5.QtWidgets import (
     QStylePainter,
 )
 
+from raphodo.internationalisation.install import install_gettext
 from raphodo.ui.viewutils import is_dark_mode, menuHoverColor
+
+install_gettext()
 
 
 class VerticalRotation(IntEnum):

--- a/raphodo/ui/sourcepanel.py
+++ b/raphodo/ui/sourcepanel.py
@@ -11,8 +11,11 @@ from PyQt5.QtCore import QPoint, QSettings, Qt, pyqtSlot
 from PyQt5.QtWidgets import QApplication, QSizePolicy, QStyle, QVBoxLayout, QWidget
 
 from raphodo.constants import TemporalProximityState
+from raphodo.internationalisation.install import install_gettext
 from raphodo.proximity import TemporalProximityControls
 from raphodo.ui.viewutils import ScrollAreaNoFrame, SourceSplitter
+
+install_gettext()
 
 
 class SourcePanel(ScrollAreaNoFrame):

--- a/raphodo/ui/viewutils.py
+++ b/raphodo/ui/viewutils.py
@@ -61,7 +61,10 @@ from PyQt5.QtWidgets import (
 
 import raphodo.tools.xsettings as xsettings
 from raphodo.constants import HeaderBackgroundName, ScalingDetected
+from raphodo.internationalisation.install import install_gettext
 from raphodo.tools.utilities import data_file_path
+
+install_gettext()
 
 QT5_VERSION = parse(QT_VERSION_STR)
 

--- a/raphodo/wsl/wsl.py
+++ b/raphodo/wsl/wsl.py
@@ -39,15 +39,18 @@ from PyQt5.QtWidgets import (
 )
 
 from raphodo.constants import WindowsDriveType
+from raphodo.internationalisation.install import install_gettext
+from raphodo.internationalisation.utilities import make_internationalized_list
 from raphodo.prefs.preferences import Preferences, WSLWindowsDrivePrefs
 from raphodo.sudocommand import SudoException, SudoExceptionCode, run_commands_as_sudo
-from raphodo.tools.utilities import make_internationalized_list
 from raphodo.ui.viewutils import (
     CheckBoxDelegate,
     standardMessageBox,
     translateDialogBoxButtons,
 )
 from raphodo.wsl.wslutils import wsl_conf_mnt_location
+
+install_gettext()
 
 
 class WindowsDrive(NamedTuple):


### PR DESCRIPTION
Move internationalisation utilities for localization into  separate module, and out of __init__.py.
Move file format extensions into new module.