### PR TITLE
build: Add configuration options for gettext hooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ manpages = [
 
 [tool.hatch.build.hooks.gettext]
 locale-directory = "raphodo/locale"
+identify-left-out = true
+regenerate-template = true
+show-report = false
 
 [tool.hatch.build.hooks.gettext.files]
 "share/applications" = ["data/net.damonlynch.rapid_photo_downloader.desktop.in"]


### PR DESCRIPTION
Enable identify-left-out and regenerate-template options