### PR TITLE
fix: avoid crash when QT_QPA_PLATFORM is unset under WSL2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ Changelog for Rapid Photo Downloader
 - Fix a crash when the system locale is set to C. Thanks to oipocorp for the
   fix.
 
+- Fix a crash when QT_QPA_PLATFORM is not set under WSL2. Thanks to oipocorp for
+  the fix.
+
 - Fix bug [#264](https://github.com/damonlynch/rapid-photo-downloader/issues/264):
   CR3 files not recognized after refactoring in commit e00e7de. Thanks to 
   sheepherder for diagnosing the problem.

--- a/raphodo/rapid.py
+++ b/raphodo/rapid.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2011-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: GPL-3.0-or-later
+#  SPDX-FileCopyrightText: 2011-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 Primary logic for Rapid Photo Downloader.
@@ -6511,11 +6511,11 @@ def main():
     this_computer_location: str | None = None
 
     try:
-        force_wayland = linux_desktop() == LinuxDesktop.wsl2
+        if not os.getenv('QT_QPA_PLATFORM'):
+            force_wayland = False
+        else:
+            force_wayland = linux_desktop() == LinuxDesktop.wsl2
     except Exception:
-        force_wayland = False
-
-    if not os.getenv('QT_QPA_PLATFORM'):
         force_wayland = False
 
     platform_cmd_line_overruled = False


### PR DESCRIPTION
Update behavior that determined whether Wayland should be forced on WSL2.
Do not force the use of Wayland when QT_QPA_PLATFORM is not set.