### PR TITLE
fix(theme): avoid forcing Fusion theme on KDE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,10 @@ Changelog for Rapid Photo Downloader
   CR3 files not recognized after refactoring in commit e00e7de. Thanks to 
   sheepherder for diagnosing the problem.
 
+- Using the Fusion theme is no longer the default when KDE is detected. This 
+  avoids invisible unchecked checkboxes when Dark Mode is activated under 
+  some desktops, e.g. KDE Neon.
+
 0.9.37a5 (2024-04-28)
 ---------------------
 

--- a/raphodo/rapid.py
+++ b/raphodo/rapid.py
@@ -6851,8 +6851,16 @@ def main():
     app.setOrganizationDomain("damonlynch.net")
     app.setApplicationName("Rapid Photo Downloader")
     app.setWindowIcon(QIcon(data_file_path("rapid-photo-downloader.svg")))
-    if not args.force_system_theme:
+
+    try:
+        is_kde = linux_desktop() == LinuxDesktop.kde
+    except KeyError:
+        is_kde = False
+
+    if not (is_kde or args.force_system_theme):
         app.setStyle("Fusion")
+    else:
+        logging.debug("Not setting Fusion theme. KDE detected: %s", is_kde)
 
     # Determine the system locale as reported by Qt. Use it to
     # see if Qt has a base translation available, which allows


### PR DESCRIPTION
Avoid setting the Fusion theme by default when the desktop is KDE. Detect
KDE via linux_desktop() and skip overriding the system theme if KDE is
detected or if --force-system-theme is specified. Add a debug log when
Fusion is not set.

This prevents invisible unchecked checkboxes in Dark Mode on some KDE
variants (e.g. KDE Neon) and documents the behavior change in CHANGES.md.