### PR TITLE
fix(datetime): use timezone-aware UTC datetime functions

### DIFF
--- a/raphodo/rpdfile.py
+++ b/raphodo/rpdfile.py
@@ -9,7 +9,7 @@ import os
 import time
 import uuid
 from collections import Counter, UserDict
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import gi
@@ -468,9 +468,10 @@ class RPDFile:
         # I'm in the timezone UTC + 5, and I take a photo at 5pm, then the time stamp on
         # the memory card shows the photo being taken at 10pm when I look at it on the
         # computer. The timestamp written to the memory card should with this camera be
-        # read as datetime.utcfromtimestamp(mtime), which would return a time zone naive
-        # value of 5pm. In other words, the timestamp on the memory card is written as
-        # if it were always in UTC, regardless of which timezone the photo was taken in.
+        # read as datetime.fromtimestamp(mtime, UTC), which would return a time zone
+        # naive value of 5pm. In other words, the timestamp on the memory card is
+        # written as if it were always in UTC, regardless of which timezone the photo
+        # was taken in.
         #
         # Yet this is not the case with a cellphone, where the file modification time
         # knows nothing about UTC and just saves it as a naive local time.
@@ -595,7 +596,7 @@ class RPDFile:
         if not isinstance(value, float):
             value = float(value)
         if self.device_timestamp_type == DeviceTimestampTZ.is_utc:
-            self._mtime = datetime.utcfromtimestamp(value).timestamp()
+            self._mtime = datetime.fromtimestamp(timestamp=value, tz=UTC).timestamp()
         else:
             self._mtime = value
         self._raw_mtime = value

--- a/raphodo/scan.py
+++ b/raphodo/scan.py
@@ -36,7 +36,7 @@ import sys
 import tempfile
 from collections import defaultdict, deque, namedtuple
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import UTC, datetime
 
 with contextlib.suppress(locale.Error):
     # Use the default locale as defined by the LANG variable
@@ -1702,9 +1702,12 @@ class ScanWorker(WorkerInPublishPullPipeline):
                         return
                 else:
                     if len(jpegs_heifs_and_videos[ext_type]) < max_attempts:
-                        jpegs_heifs_and_videos[ext_type].append(
-                            (dir_name, name, full_file_name, extension)
-                        )
+                        jpegs_heifs_and_videos[ext_type].append((
+                            dir_name,
+                            name,
+                            full_file_name,
+                            extension,
+                        ))
 
                     if len(jpegs_heifs_and_videos[FileExtension.jpeg]) == max_attempts:
                         break
@@ -1756,7 +1759,8 @@ class ScanWorker(WorkerInPublishPullPipeline):
             # between when a file was saved to the flash memory and when it was created
             # in the camera's memory. Allow for two minutes, to be safe.
             if datetime_roughly_equal(
-                dt1=datetime.utcfromtimestamp(modification_time), dt2=mdatatime
+                dt1=datetime.fromtimestamp(timestamp=modification_time, tz=UTC),
+                dt2=mdatatime,
             ):
                 logging.info(
                     "Device timezone setting for %s is UTC, as indicated by %s file",
@@ -1794,7 +1798,7 @@ class ScanWorker(WorkerInPublishPullPipeline):
         """
 
         if self.device_timestamp_type == DeviceTimestampTZ.is_utc:
-            return datetime.utcfromtimestamp(mtime).timestamp()
+            return datetime.fromtimestamp(timestamp=mtime, tz=UTC).timestamp()
         else:
             return mtime
 


### PR DESCRIPTION
Use datetime.fromtimestamp(..., tz=UTC) instead of depreciated
datetime.utcfromtimestamp in rpdfile.py and scan.py.

Also reformat a multi-item append into a vertical tuple for readability.