### PR TITLE
Recreate utcfromtimestamp() functionality

### DIFF
--- a/raphodo/rpdfile.py
+++ b/raphodo/rpdfile.py
@@ -596,7 +596,13 @@ class RPDFile:
         if not isinstance(value, float):
             value = float(value)
         if self.device_timestamp_type == DeviceTimestampTZ.is_utc:
-            self._mtime = datetime.fromtimestamp(timestamp=value, tz=UTC).timestamp()
+            # Removing the time zone from the datetime is critical
+            self._mtime = (
+                datetime
+                .fromtimestamp(timestamp=value, tz=UTC)
+                .replace(tzinfo=None)
+                .timestamp()
+            )
         else:
             self._mtime = value
         self._raw_mtime = value

--- a/raphodo/scan.py
+++ b/raphodo/scan.py
@@ -1758,8 +1758,12 @@ class ScanWorker(WorkerInPublishPullPipeline):
             # Must not compare exact times, as there can be a few seconds difference
             # between when a file was saved to the flash memory and when it was created
             # in the camera's memory. Allow for two minutes, to be safe.
+
+            # Removing the time zone from the datetime is critical
             if datetime_roughly_equal(
-                dt1=datetime.fromtimestamp(timestamp=modification_time, tz=UTC),
+                dt1=datetime.fromtimestamp(timestamp=modification_time, tz=UTC).replace(
+                    tzinfo=None
+                ),
                 dt2=mdatatime,
             ):
                 logging.info(


### PR DESCRIPTION
Recreate the functionality of the time zone naive utcfromtimestamp() by
removing the time zone created by the command fromtimestamp(tz=UTC)