### PR TITLE
refactor(i18n): replace deprecated locale.getdefaultlocale usage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@ Changelog for Rapid Photo Downloader
 
 - Handle python-gphoto2 API change in CameraList iterators.
 
+- Purge use of depreciated Python function locale.getdefaultlocale().
+
 0.9.37a5 (2024-04-28)
 ---------------------
 

--- a/raphodo/internationalisation/install.py
+++ b/raphodo/internationalisation/install.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2016-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: GPL-3.0-or-later
+#  SPDX-FileCopyrightText: 2016-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 Initialize gettext translations.
@@ -67,7 +67,7 @@ def install_gettext() -> None:
         settings.endGroup()
 
         if not lang:
-            lang, encoding = locale.getdefaultlocale()
+            lang, encoding = locale.getlocale()
 
         try:
             gnulang = gettext.translation(

--- a/raphodo/internationalisation/utilities.py
+++ b/raphodo/internationalisation/utilities.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2007-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: GPL-3.0-or-later
+#  SPDX-FileCopyrightText: 2007-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: GPL-3.0-or-later
 
 import locale
 
@@ -81,6 +81,7 @@ def thousands(i: int) -> str:
     except TypeError:
         return str(i)
 
+
 def current_locale() -> str:
     assert have_pyqt
     settings = QSettings("Rapid Photo Downloader", "Rapid Photo Downloader")
@@ -89,5 +90,7 @@ def current_locale() -> str:
     settings.endGroup()
     if lang:
         return lang
-    lang, encoding = locale.getdefaultlocale()
-    return lang
+
+    # The "C" locale is represented as (None, None).
+    lang, encoding = locale.getlocale()
+    return lang or ""

--- a/raphodo/tools/utilities.py
+++ b/raphodo/tools/utilities.py
@@ -839,7 +839,7 @@ def arrow_locale(lang: str) -> str:
     default = "en_us"
     if not lang:
         try:
-            lang = locale.getdefaultlocale()[0]
+            lang = locale.getlocale()[0]
         except Exception:
             return default
 
@@ -1057,7 +1057,7 @@ def available_languages(display_locale_code: str = "") -> list[tuple[str, str]]:
 
     if not display_locale_code:
         try:
-            locale_code = locale.getdefaultlocale()[0]
+            locale_code = locale.getlocale()[0]
         except Exception:
             locale_code = "en_US"
     else:


### PR DESCRIPTION
Update code to stop using the deprecated locale.getdefaultlocale()
and switch to locale.getlocale across the internationalisation modules.
Adjust current_locale to handle the "C" locale by returning an
empty string when getlocale yields None. Bump SPDX copyright
years to 2026. Update CHANGES.md entry to note removal of the
deprecated function. These changes avoid relying on a deprecated
API and ensure safer locale handling in edge cases.