### PR TITLE
Fix #244 Changing language causes settings to fail to open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,9 @@ Changelog for Rapid Photo Downloader
 
 - Purge use of depreciated Python function locale.getdefaultlocale().
 
+- Fix bug [#244](https://github.com/damonlynch/rapid-photo-downloader/issues/244):
+  Changing language causes settings to fail to open. 
+
 0.9.37a5 (2024-04-28)
 ---------------------
 

--- a/raphodo/tools/utilities.py
+++ b/raphodo/tools/utilities.py
@@ -1068,7 +1068,7 @@ def available_languages(display_locale_code: str = "") -> list[tuple[str, str]]:
         babel_sample = babel.Locale.parse("en").get_display_name(locale_code)
     except babel.core.UnknownLocaleError:
         locale_code = "en_US"
-    babel_sample = babel.Locale.parse("en").get_display_name(locale_code)
+        babel_sample = babel.Locale.parse("en").get_display_name(locale_code)
     make_missing_lower = babel_sample.islower()
 
     langs = zip(


### PR DESCRIPTION
Fixes an indentation bug in utilities.py related to an earlier fix for
issue #244, which should now be fixed.