### PR TITLE
fix(ui): use package copyright string in about dialog

### DIFF
--- a/raphodo/ui/aboutdialog.py
+++ b/raphodo/ui/aboutdialog.py
@@ -74,7 +74,11 @@ class AboutDialog(QDialog):
         gpl3link = "https://www.gnu.org/licenses/gpl-3.0.html"
         lgpl3link = "https://www.gnu.org/licenses/lgpl-3.0.html"
 
-        msg = f"""Copyright &copy; 2007-2024 Damon Lynch.<br><br>
+        rpd_copyright = __about__.__copyright__.replace(
+            "Copyright ", "Copyright &copy; "
+        )
+
+        msg = f"""{rpd_copyright}.<br><br>
         <a href="https://damonlynch.net/rapid" {link_style}>
         damonlynch.net/rapid</a><br><br>
         This program comes with absolutely no warranty.<br>
@@ -155,7 +159,7 @@ class AboutDialog(QDialog):
             qt_licence = lgpl3desc
 
         credits_text = f"""
-        Copyright © 2007-2026 Damon Lynch.
+        {rpd_copyright}.
         Portions copyright © 2008-2015 Canonical Ltd.
         Portions copyright © 2013 Bernard Baeyens.
         Portions copyright © 2012-2015 Jim Easterbrook.


### PR DESCRIPTION
Replace hardcoded copyright text in the About dialog with the
package's __about__.__copyright__ value, formatting it to include
an HTML copyright entity. This ensures the displayed years and
owner remain consistent with the package metadata and avoids
duplicating or drifting copyright strings in the UI.

Also update the credits block to reference the same formatted string
instead of a separate hardcoded copyright line.