### PR TITLE
fix(gexiv2): support GExiv2 0.16 and fix Canon file number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@ Changelog for Rapid Photo Downloader
 
 - Updated RELEASE_NOTES.md
 
+- Fix bug [#300](https://github.com/damonlynch/rapid-photo-downloader/issues/300):
+  Support for GExiv2 0.16.
+
+- Fix bug retrieving Canon File Number metadata using ExifTool.
 
 0.9.37b1 (2026-02-11)
 ---------------------

--- a/raphodo/metadata/metadataphoto.py
+++ b/raphodo/metadata/metadataphoto.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2007-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: GPL-3.0-or-later
+#  SPDX-FileCopyrightText: 2007-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: GPL-3.0-or-later
 
 # ruff: noqa: E402
 
@@ -9,7 +9,10 @@ from typing import Any
 
 import gi
 
-gi.require_version("GExiv2", "0.10")
+try:
+    gi.require_version("GExiv2", "0.16")
+except ValueError:
+    gi.require_version("GExiv2", "0.10")
 from gi.repository import GExiv2
 from PyQt5.QtCore import QSize
 
@@ -33,7 +36,6 @@ VENDOR_SERIAL_CODES = (
 VENDOR_SHUTTER_COUNT = (
     "Exif.Nikon3.ShutterCount",
     "Exif.Canon.FileNumber",
-    "Exif.Canon.ImageNumber",
 )
 
 
@@ -311,10 +313,14 @@ class MetaData(metadataexiftool.MetadataExiftool, GExiv2.Metadata):
 
         See:
         https://bugs.launchpad.net/rapid/+bug/754531
+
+        (bug still open as at February 2026)
+        CR3 files may not have this value
         """
-        if "Exif.CanonFi.FileNumber" in self and self.full_file_name is not None:
+        if self.full_file_name is not None:
             assert self.et_process is not None
             return super().file_number(missing)
+        return missing
 
     def owner_name(self, missing=""):
         try:

--- a/raphodo/programversions.py
+++ b/raphodo/programversions.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2015-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: GPL-3.0-or-later
+#  SPDX-FileCopyrightText: 2015-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 Detect versions of external programs.
@@ -11,7 +11,10 @@ import subprocess
 
 import gi
 
-gi.require_version("GExiv2", "0.10")
+try:
+    gi.require_version("GExiv2", "0.16")
+except ValueError:
+    gi.require_version("GExiv2", "0.10")
 from gi.repository import GExiv2  # noqa: E402
 
 

--- a/raphodo/storage/storage.py
+++ b/raphodo/storage/storage.py
@@ -48,7 +48,10 @@ import gi
 
 gi.require_version("GUdev", "1.0")
 gi.require_version("UDisks", "2.0")
-gi.require_version("GExiv2", "0.10")
+try:
+    gi.require_version("GExiv2", "0.16")
+except ValueError:
+    gi.require_version("GExiv2", "0.10")
 gi.require_version("GLib", "2.0")
 from gi.repository import GLib, GUdev, UDisks
 from PyQt5.QtCore import (


### PR DESCRIPTION
Update GExiv2 requirement to try 0.16 first and fall back to 0.10,
so the app works with newer GExiv2 releases while preserving
compatibility with older versions.

Adjust SPDX copyright years to 2026 in updated modules.

Fix Canon file number retrieval logic when ExifTool is not available
or CR3 files lack the value: return the missing sentinel instead of
incorrectly attempting to access Exif data.

Update CHANGES.md and RELEASE_NOTES references.