### PR TITLE
feat: add support for NEV, BRAW and CRM video formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,12 @@ Changelog for Rapid Photo Downloader
 
 - Fix bug retrieving Canon File Number metadata using ExifTool.
 
-0.9.37b1 (2026-02-11)
+- Add support for Nikon N-RAW (.NEV), Blackmagic RAW (.BRAW), and Canon 
+  Cinema RAW Light (.CRM), using MediaInfo and ExifTool. Thumbnail 
+  generation for these formats is currently unsupported. Fixes bug 
+  [#88](https://github.com/damonlynch/rapid-photo-downloader/issues/88).
+
+- 0.9.37b1 (2026-02-11)
 ---------------------
 
 - Fix bug [#261](https://github.com/damonlynch/rapid-photo-downloader/issues/261):

--- a/raphodo/metadata/fileformats.py
+++ b/raphodo/metadata/fileformats.py
@@ -111,6 +111,9 @@ VIDEO_EXTENSIONS = [
     "mod",
     "tod",
     "mts",
+    "nev",
+    "braw",
+    "crm",
 ]
 VIDEO_EXTENSIONS.sort()
 


### PR DESCRIPTION
Fix #88:

Add Nikon N-RAW (.nev), Blackmagic RAW (.braw), and Canon Cinema RAW
Light (.crm) to recognized video extensions so they are detected and
processed by the importer. Update CHANGES.md to document the new format
support and note that thumbnail generation for these formats is not
currently supported. Also include a reference to the related issue fix
[#88] and bump the changelog entry for version 0.9.37b1.

This change enables users to import these raw camera video files using
existing MediaInfo/ExifTool pipelines and improves format coverage.