### PR TITLE
docs: update build instructions and changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,20 @@
 Changelog for Rapid Photo Downloader
 ====================================
 
-0.9.37b2 (2026-02-1x)
+0.9.37b2 (2026-02-15)
 ---------------------
 
-- Corrected build configuration error in tarball of 0.9.37b1 release, which 
-  resulted in incorrect file selection.
+- Corrected a build configuration error in tarball of 0.9.37b1 release.
 
 - Consequently, `hatch build -t sdist` now produces an archive of the project's 
-  source code, suitable for ingestion by Linux distro packagers.
+  source code.
 
 - Additionally, `hatch build -t wheel` now produces a wheel (zip archive) of 
   the program's Python code, as well as associated compiled files, i.e. 
   manpage, `.mo` files used for internationalization, and appstream and
   `.desktop` files.  
 
-- Updated RELEASE_NOTES.md
+- Updated RELEASE_NOTES.md and INSTALL.md.
 
 - Fix bug [#300](https://github.com/damonlynch/rapid-photo-downloader/issues/300):
   Support for GExiv2 0.16.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,10 +1,43 @@
-# Installing Rapid Photo Downloader from Source
+# Building Rapid Photo Downloader from Source
 
-Installation requires Python package dependencies that themselves depend on 
-non-python programs to function. For example, `python-gphoto2` requires  
-`libgphoto2`.
+## Building Rapid Photo Downloader
+
+Use [Hatch](https://hatch.pypa.io/latest/) to build Rapid Photo Downloader. 
+There are two build targets: `sdist` and `wheel`.
+
+### Building an sdist archive
+
+This produces an archive of the project's source code and data files. 
+
+```bash
+hatch build -t sdist
+```
+
+### Building a wheel
+
+This produces a wheel (zip archive) of the program's Python code, as well as 
+associated compiled files, i.e. manpage, `.mo` files used for 
+internationalization, and appstream and `.desktop` files.  
+
+```bash
+hatch build -t wheel
+```
+
+Running the build creates desktop integration files in the `share` folder, 
+and a manpage and the `man` folder (localization files should not be installed 
+system-wide).
+
+## Build dependencies
+
+ - [Hatch](https://github.com/pypa/hatch)
+ - [Hatch-gettext](https://github.com/damonlynch/hatch-gettext)
+ - [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage)
+ - `intltool`
 
 ## Runtime dependencies
+
+Python package dependencies themselves depend on non-python programs to 
+function. For example, `python-gphoto2` requires `libgphoto2`.
 
  - Python 3.10 or newer, and its development headers
  - [PyQt 5](https://riverbankcomputing.com/software/pyqt/intro)
@@ -43,28 +76,5 @@ non-python programs to function. For example, `python-gphoto2` requires
         
 Recommended, optional dependencies:
 
- - [colorlog](https://github.com/borntyping/python-colorlog): generates coloured program output when
-   running Rapid Photo Downloader from the terminal.
- - [pyheif](https://github.com/david-poirier-csn/pyheif): generate 
-   thumbnails for HEIF / HEIC files (currently broken with recent releases 
-   of [libheif](https://github.com/strukturag/libheif)).
- - [pillow](https://github.com/python-pillow/Pillow): work with HEIF / HEIC files
-
-## Build dependencies
-
- - [Hatch](https://github.com/pypa/hatch)
- - [Hatch-gettext](https://github.com/damonlynch/hatch-gettext)
- - [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage)
- - `intltool`
-
-## Building Rapid Photo Downloader
-
-### Building a sdist distribution
-
-```bash
-hatch build -t sdist
-```
-### Building a sdist distribution
-
-Running the build creates desktop integration files in the `share` folder 
-(localization files do not need to be installed system-wide).  
+ - [colorlog](https://github.com/borntyping/python-colorlog): generates 
+   coloured program output when running Rapid Photo Downloader from the terminal. 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,13 +30,6 @@ Release Notes for Rapid Photo Downloader 0.9.37
      copyright and licensing.
    - The Python package easygui has been purged, and is no longer a dependency.
 
- - The Python package used to generate thumbnails from HEIF / HEIC 
-   images, [pyheif](https://github.com/carsales/pyheif), requires updating 
-   to work with recent versions of 
-   [libheif](https://github.com/strukturag/libheif). This means `pyheif` 
-   currently does not work, and therefore Rapid Photo Downloader cannot use it
-   to generate thumbnails from HEIF / HEIC images.
-
  - To run Rapid Photo Downloader under WSLg on Windows 11, using the 
    [Windows Subsystem for Linux](https://aka.ms/wslstorepage) from 
    the Microsoft Store is *strongly recommended*. Using the version of WSL that


### PR DESCRIPTION
Update CHANGES.md, RELEASE_NOTES.md, and INSTALL.md to fix and clarify
build-related information.

- Note errors in build configuration description for 0.9.37b1 tarball
  in CHANGES.md and update the release date.
- Note that RELEASE_NOTES.md and INSTALL.md were updated.
- Replace INSTALL.md contents with concise, clear Hatch-based build
  instructions for both sdist and wheel targets, including commands and
  what each target produces (manpage, .mo files, appstream, .desktop,
  share folder).
- Move and consolidate build dependency listings into INSTALL.md and
  trim duplicated/obsolete notes about optional packages and HEIF/HEIC
  thumbnail issues from RELEASE_NOTES.md.

These changes make the packaging/build instructions accurate and easier
for maintainers and packagers to follow.