### PR TITLE
chore(release): publish 0.9.37 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog for Rapid Photo Downloader
 
-## 0.9.37b2 (2026-02-15)
+## 0.9.37 (2026-02-18)
 
 - Corrected a build configuration error in tarball of 0.9.37b1 release.
 - Consequently, `hatch build -t sdist` now produces an archive of the project's source code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -86,7 +85,7 @@ packages = ["raphodo", "man", "share", "/*.md"]
 
 [tool.hatch.build.targets.sdist]
 include = ["raphodo", "data", "po", "/*.md"]
-exclude = [".github"]
+exclude = [".github", ".gitignore"]
 
 [tool.hatch.build.targets.wheel.hooks.argparse-manpage]
 include-url = false

--- a/raphodo/__about__.py
+++ b/raphodo/__about__.py
@@ -19,7 +19,7 @@ __summary__ = (
 )
 __uri__ = "https://damonlynch.net/rapid"
 
-__version__ = "0.9.37b2"
+__version__ = "0.9.37"
 
 __author__ = "Damon Lynch"
 __email__ = "damonlynch@gmail.com"


### PR DESCRIPTION
Bump release version to 0.9.37 and update changelog to reflect the
official release date.

Fix sdist packaging to include project metadata by excluding .gitignore
from the sdist exclude list (previously only .github was excluded),
allowing hatch build -t sdist to produce a correct source archive. Also
remove an explicit Python 3.10 trove classifier from pyproject.toml to
keep supported Python versions accurate.

These changes correct a build/configuration error discovered in the
0.9.37b2 tarball and ensure the source distribution contains the
expected files and metadata.