### PR TITLE
Install desktop, metainfo, and solid action files to /usr/share/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ packages = ["raphodo", "man", "/*.md"]
 
 [tool.hatch.build.targets.wheel.shared-data]
 "share" = "share"
+"data/icons" = "share/icons/hicolor"
 
 [tool.hatch.build.targets.sdist]
 include = ["raphodo", "data", "po", "/*.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ Source = "https://github.com/damonlynch/rapid-photo-downloader"
 path = "raphodo/__about__.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["raphodo", "man", "share", "/*.md"]
+packages = ["raphodo", "man", "/*.md"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"share" = "share"
 
 [tool.hatch.build.targets.sdist]
 include = ["raphodo", "data", "po", "/*.md"]


### PR DESCRIPTION
The share directory was listed in the wheel packages list, causing its contents to be installed under dist-packages/share/ instead of /usr/share/. Move it to the shared-data section so hatchling places these files in the wheel's data directory, which installs to the correct system path.
