### PR TITLE
Increase database access robustness (workaround for 'database is locked' errors)

### DIFF
--- a/raphodo/rpdsql.py
+++ b/raphodo/rpdsql.py
@@ -737,17 +737,19 @@ class DownloadedSQL:
         # h:mm. Set to actual offset when one is found. Can be negative.
         self.found_offset_hr = ""
 
+    @retry(stop=stop_after_attempt(sqlite3_retry_attempts))
     def no_downloaded(self) -> None:
         """
         :return: how many downloaded files are in the db
         """
 
-        with closing(sqlite3.connect(self.db)) as conn:
+        with closing(sqlite3.connect(self.db, timeout=sqlite3_timeout)) as conn:
             c = conn.cursor()
             c.execute(f"SELECT COUNT(*) FROM {self.table_name}")
             count = c.fetchall()
             return count[0][0]
 
+    @retry(stop=stop_after_attempt(sqlite3_retry_attempts))
     def update_table(self, reset: bool = False) -> None:
         """
         Create or update the database table
@@ -756,7 +758,9 @@ class DownloadedSQL:
         """
 
         with closing(
-            sqlite3.connect(self.db, detect_types=sqlite3.PARSE_DECLTYPES)
+            sqlite3.connect(
+                self.db, detect_types=sqlite3.PARSE_DECLTYPES, timeout=sqlite3_timeout
+            )
         ) as conn:
             if reset:
                 conn.execute(rf"""DROP TABLE IF EXISTS {self.table_name}""")
@@ -825,6 +829,7 @@ class DownloadedSQL:
             else:
                 conn.commit()
 
+    @retry(stop=stop_after_attempt(sqlite3_retry_attempts))
     def file_downloaded(
         self,
         name: str,
@@ -842,7 +847,9 @@ class DownloadedSQL:
          downloaded, else None if never downloaded
         """
         with closing(
-            sqlite3.connect(self.db, detect_types=sqlite3.PARSE_DECLTYPES)
+            sqlite3.connect(
+                self.db, detect_types=sqlite3.PARSE_DECLTYPES, timeout=sqlite3_timeout
+            )
         ) as conn:
             c = conn.cursor()
             c.execute(


### PR DESCRIPTION
### Summary
This PR improves the robustness of database access in `DownloadedSQL`, addressing a recurring 'Device scan failed' error (as shown in the provided `img.png`) when scanning SD cards or other devices.

### Description of the Issue
The error 'Sorry, an unexpected problem occurred while scanning...' would appear frequently during device scans. The root cause is a `sqlite3.OperationalError: database is locked` in `raphodo/rpdsql.py` when multiple processes attempted to access the `downloaded_files.sqlite` database simultaneously without a timeout or retry mechanism. This PR implements a workaround to handle these transient locks more gracefully.

### Changes Made
-   Implemented a workaround to increase robustness: added `timeout=10.0` to `sqlite3.connect()` calls in the `DownloadedSQL` class within `raphodo/rpdsql.py`.
-   Applied `@retry` decorators to the `no_downloaded`, `update_table`, and `file_downloaded` methods to provide a more resilient handling of transient database locking issues.
-   These changes bring consistency to the codebase, matching existing patterns (e.g., `add_downloaded_file`) that already use these safeguards.

### Verification
-   Confirmed that no database locking or concurrency errors occurred during high-load scanning phases.

<img width="513" height="436" alt="img" src="https://github.com/user-attachments/assets/7efe43c7-e9cd-4b22-b93d-c05e0d0af384" />